### PR TITLE
Remove old blog post

### DIFF
--- a/data/blog.json
+++ b/data/blog.json
@@ -1,13 +1,5 @@
 [
   {
-    "id": "devfest-switerland-2018-speakers",
-    "title": "GDG DevFest Switzerland 2018 Speaker announced",
-    "posted": "2018-09-15",
-    "primaryColor": "#3F51B5",
-    "secondaryColor": "#3F51B5",
-    "image": "/images/posts/announce.jpg",
-    "brief": "The speakers have been selected"
-  },  {
     "id": "devfest-switzerland-2018-announced",
     "title": "GDG DevFest Switzerland 2018 Announced",
     "posted": "2018-05-01",


### PR DESCRIPTION
i think that it made it into `develop` during one of the merge conflicts... let's get rid of it 😉 

![image](https://user-images.githubusercontent.com/326935/46374544-36fe6780-c691-11e8-85f3-d20d2ec75d9e.png)
